### PR TITLE
Adjust attribute name of tags with following rules:

### DIFF
--- a/lib/parseAttributes.js
+++ b/lib/parseAttributes.js
@@ -6,6 +6,7 @@
  *  - Attribute keys should only match 1 of the following 2 patterns:
  *    - String ("data-key"="value" key="value")
  *    - Symbol with hyphen (data-key="value")
+ *  - Attributes without value must be a simple symbol or an expression
  *
  * thanks to @Gerhut
  */
@@ -16,22 +17,20 @@ module.exports = function(parser, nodes, lexer) {
   const kwargs = new nodes.KeywordArgs(tok.lineno, tok.colno);
 
   while (tok.type !== lexer.TOKEN_BLOCK_END) { // 如果标签结束，则结束解析
-    let arg;
-    if (tok.type === lexer.TOKEN_SYMBOL) {
-      // 解析 foo-bar 的情况
-      arg = parseHyphenSymbol(parser, nodes, lexer);
-    } else if (tok.type === lexer.TOKEN_STRING) {
-      // 解析 "foo-bar" 的情况
-      arg = parser.parseExpression();
-    } else {
-      parser.fail('parseAttributes: expected attribute name or string', tok.lineno, tok.colno);
-    }
+    let arg = parser.parseExpression();
 
     if (parser.skipValue(lexer.TOKEN_OPERATOR, '=')) {
+      // 有等于号，确保左值符合 foo-bar 格式，转为字符串处理
+      let attrName = toAttributeName(arg, true);
+      if (attrName === null) {
+        parser.fail('parseAttributes: invalid key name.');
+      }
+      arg = new nodes.Literal(arg.lineno, arg.colno, attrName);
       kwargs.addChild(
         new nodes.Pair(arg.lineno, arg.colno, arg, parser.parseExpression())
       );
     } else {
+      // 无等于号：左值当表达式处理
       args.addChild(arg);
     }
 
@@ -48,24 +47,19 @@ module.exports = function(parser, nodes, lexer) {
   return args;
 };
 
-function parseHyphenSymbol(parser, nodes, lexer) {
-  let tok = parser.peekToken();
-  const lineno = tok.lineno;
-  const colno = tok.colno;
-  let val = '';
-
-  do {
-    tok = parser.peekToken();
-
-    if (tok.type === lexer.TOKEN_SYMBOL) {
-      // 是符号
-      tok = parser.nextToken();
-      val += tok.value + '-';
-    } else {
-      parser.fail('parseAttributeName: expected attribute symbol', tok.lineno, tok.colno);
+function toAttributeName(arg, acceptLiteral) {
+  if (acceptLiteral && arg.typename === 'Literal'
+      || arg.typename === 'Symbol') {
+    return arg.value;
+  }
+  if (arg.typename === 'Sub') {
+    let left = toAttributeName(arg.left, false);
+    let right = toAttributeName(arg.right, false);
+    if (left === null || right === null) {
+      return null;
     }
-  } while (parser.skipValue(lexer.TOKEN_OPERATOR, '-')); // 无分隔符，结束解析
-  // 截掉最后一个分隔符
-  val = val.slice(0, val.length - 1);
-  return new nodes.Literal(lineno, colno, val);
+    return `${left}-${right}`;
+  }
+
+  return null;
 }

--- a/test/lib/parseAttributes.test.js
+++ b/test/lib/parseAttributes.test.js
@@ -28,7 +28,9 @@ describe('test/lib/parseAttributes.test.js', function() {
       bar: 'bar'
     },
     html: '<img src=>',
-    jsonStr: JSON.stringify({a: 'b'})
+    jsonStr: JSON.stringify({a: 'b'}),
+    data: 'foo',
+    attr3: 'bar'
   };
 
   let testCases = [
@@ -39,7 +41,6 @@ describe('test/lib/parseAttributes.test.js', function() {
     ['data-attr=clz', 'data-attr="test"'],
     ['"data-attr"=clz', 'data-attr="test"'],
     ['"data-attr-1-a"=clz', 'data-attr-1-a="test"'],
-    ['disabled', 'disabled'],
     ['"checked"', 'checked'],
     ['class=["test1", clz]', 'class="test1 test"'],
     ['class=["test1"], style=clz', 'class="test1" style="test"'],
@@ -52,7 +53,8 @@ describe('test/lib/parseAttributes.test.js', function() {
     ['class="\'"', 'class="&#39;"'],
     ['class=jsonStr', 'class="{&quot;a&quot;:&quot;b&quot;}"'],
     ['class=html', 'class="&lt;img src=&gt;"'],
-    ['class=html|safe', 'class="<img src=>"']
+    ['class=html|safe', 'class="<img src=>"'],
+    ['data+attr3', 'foobar']
   ];
   testCases.forEach((item) => {
     it('should parse: ' + item[0], function() {
@@ -68,7 +70,7 @@ describe('test/lib/parseAttributes.test.js', function() {
     env.addExtension('custom', tag);
     let tpl = '{% custom data-attr1=attr1 "data-attr2"=2+3 class=["a1", attr2, "a1", deep.foo] style={a: true, b: false, c: bool}, "readonly", attr2, undefinedVar, undefinedValue=aaa%}{{ content }}{% endcustom %}';
     let html = env.renderString(tpl, locals);
-    expect(html).to.equal('<custom readonly attr2 undefinedVar data-attr1="some attr" data-attr2="5" class="a1 a2 foo" style="a c" undefinedValue="">this is content</custom>');
+    expect(html).to.equal('<custom readonly a2 data-attr1="some attr" data-attr2="5" class="a1 a2 foo" style="a c" undefinedValue="">this is content</custom>');
 
     // without attrs
     tpl = '{% custom %}{{ content }}{% endcustom %}';


### PR DESCRIPTION
- Attribute key of key-value attributes should only match 1 of the following 2 patterns:
  - String Literal ("data-key"="value" key="value")
  - Symbol with hyphen (data-key="value")
- Attribute key of simple key attributes must be a simple symbol or an
  expression.
